### PR TITLE
Define unicode for Python 3

### DIFF
--- a/pgportfolio/tools/configprocess.py
+++ b/pgportfolio/tools/configprocess.py
@@ -7,6 +7,11 @@ import os
 rootpath = os.path.dirname(os.path.abspath(__file__)).\
     replace("\\pgportfolio\\tools", "").replace("/pgportfolio/tools","")
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 def preprocess_config(config):
     fill_default(config)


### PR DESCRIPTION
unicode was dropped from Python 3 because all strs are Unicode.

[input()](https://docs.python.org/3/library/functions.html#input) is a builtin function in both Python 2 and 3 so it is not advisable to use it as a variable name.