### PR TITLE
adding new layers and supporting multiple pre-configured networks in net config

### DIFF
--- a/pgportfolio/autotrain/generate.py
+++ b/pgportfolio/autotrain/generate.py
@@ -18,14 +18,24 @@ def add_packages(config, repeat=1):
         max_dir_num = 0
     indexes = []
 
-    for i in range(repeat):
-        max_dir_num += 1
-        directory = package_dir+"/"+str(max_dir_num)
-        config["random_seed"] = i
-        os.makedirs(directory)
-        indexes.append(max_dir_num)
-        with open(directory + "/" + "net_config.json", 'w') as outfile:
-            json.dump(config, outfile, indent=4, sort_keys=True)
+    if isinstance(config, dict):
+        for i in range(repeat):
+            max_dir_num += 1
+            directory = package_dir+"/"+str (max_dir_num)
+            config["random_seed"] = i
+            os.makedirs(directory)
+            indexes.append(max_dir_num)
+            with open(directory + "/" + "net_config.json", 'w') as outfile:
+                json.dump(config, outfile, indent=4, sort_keys=True)
+    else:  # isinstance(config, list): -- cointains multiple networks
+        for i in range(len(config)):
+            max_dir_num += 1
+            directory = package_dir+"/"+str(max_dir_num)
+            config[i]["random_seed"] = i
+            os.makedirs(directory)
+            indexes.append(max_dir_num)
+            with open(directory + "/" + "net_config.json", 'w') as outfile:
+                json.dump(config[i], outfile, indent=4, sort_keys=True)
     logging.info("create indexes %s" % indexes)
     return indexes
 

--- a/pgportfolio/learn/network.py
+++ b/pgportfolio/learn/network.py
@@ -80,6 +80,10 @@ class CNN(NeuralNetWork):
                 network = tflearn.layers.conv.avg_pool_2d(network, layer["strides"])
             elif layer["type"] == "LocalResponseNormalization":
                 network = tflearn.layers.normalization.local_response_normalization(network)
+            elif layer["type"] == "BatchNormalization":
+                network = tf.layers.batch_normalization(network, axis=-1)
+            elif layer["type"] == "ReLU":
+                network = tflearn.activations.relu(network)
             elif layer["type"] == "EIIE_Output":
                 width = network.get_shape()[2]
                 network = tflearn.layers.conv_2d(network, 1, [1, width], padding="valid",

--- a/pgportfolio/learn/rollingtrainer.py
+++ b/pgportfolio/learn/rollingtrainer.py
@@ -34,15 +34,15 @@ class RollingTrainer(TraderTrainer):
         if not fast_train:
             tflearn.is_training(False, self._agent.session)
 
-            v_pv, v_log_mean = self._evaluate("validation",
-                                              self._agent.portfolio_value,
-                                              self._agent.log_mean)
+            # v_pv, v_log_mean = self._evaluate("validation",
+            #                                   self._agent.portfolio_value,
+            #                                   self._agent.log_mean)
             t_pv, t_log_mean = self._evaluate("test", self._agent.portfolio_value, self._agent.log_mean)
             loss_value = self._evaluate("training", self._agent.loss)
 
             logging.info('training loss is %s\n' % loss_value)
-            logging.info('the portfolio value on validation asset is %s\nlog_mean is %s\n' %
-                         (v_pv,v_log_mean))
+            # logging.info('the portfolio value on validation asset is %s\nlog_mean is %s\n' %
+            #              (v_pv,v_log_mean))
             logging.info('the portfolio value on test asset is %s\n mean is %s' % (t_pv,t_log_mean))
 
     def decide_by_history(self, history, last_w):

--- a/pgportfolio/tools/configprocess.py
+++ b/pgportfolio/tools/configprocess.py
@@ -3,6 +3,7 @@ import sys
 import time
 from datetime import datetime
 import json
+import commentjson
 import os
 rootpath = os.path.dirname(os.path.abspath(__file__)).\
     replace("\\pgportfolio\\tools", "").replace("/pgportfolio/tools","")
@@ -67,7 +68,9 @@ def fill_layers_default(layers):
                 layer["type"] == "EIIE_Output_WithW":
             set_missing(layer, "regularizer", None)
             set_missing(layer, "weight_decay", 0.0)
-        elif layer["type"] == "DropOut":
+        elif layer["type"] == "BatchNormalization" or \
+                layer["type"] == "ReLU" or \
+                layer["type"] == "LocalResponseNormalization":
             pass
         else:
             raise ValueError("layer name {} not supported".format(layer["type"]))
@@ -104,7 +107,14 @@ def load_config(index=None):
             config = json.load(file)
     else:
         with open(rootpath+"/pgportfolio/" + "net_config.json") as file:
-            config = json.load(file)
+            config = commentjson.load(file)
+            if "networks" in config:
+                net_configs = []
+                for net in config['networks']:
+                    net_configs.append(
+                        preprocess_config(net['config'])
+                    )
+                return net_configs
     return preprocess_config(config)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pympler>=0.5
 cvxopt>=1.1.9
 seaborn>=0.8.1
 pandas>=0.20.3
+commentjson>=0.6


### PR DESCRIPTION
Major changes include:
1. Adding support for additional layers such as Batch Normalization and ReLU
2. Support for multiple pre-configured networks in `net_config.json`. For example, now `net_config.json` can look like the following:

```
{
  "networks": [
    {
      "copies": 1,
      "description": "default network with online and slow train",
      "config": {
        "layers":
        [
          {"filter_shape": [1, 2], "filter_number": 3, "type": "ConvLayer"},
          {"filter_number":10, "type": "EIIE_Dense", "regularizer": "L2", "weight_decay": 5e-9},
          {"type": "EIIE_Output_WithW","regularizer": "L2", "weight_decay": 5e-8}
        ],
        "training":{
          "steps":40000,
          "learning_rate":0.00028,
          "batch_size":109,
          "buffer_biased":5e-5,
          "snap_shot":false,
          "fast_train":false,
          "training_method":"Adam",
          "loss_function":"loss_function6"
        },

        "input":{
          "window_size":31,
          "coin_number":11,
          "global_period":1800,
          "feature_number":3,
          "test_portion":0.08,
          "online":true,
          "start_date":"2018/01/01",
          "end_date":"2018/02/18",
          "volume_average_days":30
        },

        "trading":{
          "trading_consumption":0.0025,
          "rolling_training_steps":85,
          "learning_rate":0.00028,
          "buffer_biased":5e-5
        }
      }
    },
    {
      <additional networks...>
    }
  ]
}
```
 The original `net_config.json` is still supported. 