### PR TITLE
Fix the issue of downloading long-period data

### DIFF
--- a/pgportfolio/marketdata/globaldatamatrix.py
+++ b/pgportfolio/marketdata/globaldatamatrix.py
@@ -188,6 +188,15 @@ class HistoryManager:
             connection.close()
 
     def __fill_data(self, start, end, coin, cursor):
+        duration = 7819200 # three months
+        bk_start = start
+        for bk_end in range(start+duration-1, end, duration):
+            self.__fill_part_data(bk_start, bk_end, coin, cursor)
+            bk_start += duration
+        if bk_start < end:
+            self.__fill_part_data(bk_start, end, coin, cursor)
+
+    def __fill_part_data(self, start, end, coin, cursor):
         chart = self._coin_list.get_chart_until_success(
             pair=self._coin_list.allActiveCoins.at[coin, 'pair'],
             start=start,


### PR DESCRIPTION
This ticket fixes the issue addressed in #119.  Set a duration time and if the target period is over the time, download files in sections. I set the duration as 3 months since I failed at setting it as 4 months. 